### PR TITLE
Accept fuzzy symbols

### DIFF
--- a/main.go
+++ b/main.go
@@ -131,6 +131,7 @@ func main() {
 			address, ok = IsDigit(result["addr"])
 			if !ok {
 				log.Error("Invalid address", "addr", result["addr"])
+				return
 			}
 		}
 
@@ -150,6 +151,12 @@ func main() {
 			symbol = result["sym"]
 			offset = address
 		}
+		ksym, err := KsymByName(symbol)
+		if err != nil {
+			log.Error("Failed to find ksym", "symbol", symbol, "err", err)
+			return
+		}
+		symbol = ksym.Name
 
 		if attachByLine {
 			kcore, err := NewKcore()


### PR DESCRIPTION
So `ktcpdump -i __netif_receive_skb_core` can be converted to `ktcpdump -i __netif_receive_skb_core.constprop.0` automatically.